### PR TITLE
fix(file): support moving files to multiple folders at once

### DIFF
--- a/src/pages/move/file/[fileId].json.ts
+++ b/src/pages/move/file/[fileId].json.ts
@@ -37,12 +37,11 @@ export const post: APIRoute = async ({ params, request, cookies }) => {
     });
   }
 
-  const promises = folderIds.map((folderId) => {
-    return folderService.addFiles(Number(folderId), [file], user.id);
-  });
-
   try {
-    await Promise.all(promises);
+    for (let i = 0; i < folderIds.length; i++) {
+      const folderId = Number(folderIds[i]);
+      await folderService.addFiles(folderId, [file], user.id);
+    }
   } catch {
     // TODO: more granular error handling
     return new Response(JSON.stringify({ error: "Error moving file." }), {


### PR DESCRIPTION
Prisma can't handle `Promise.all` for update operations.

[Relevant thread](https://github.com/prisma/prisma/issues/9562#issuecomment-998942355)